### PR TITLE
Added ZZZ Global support

### DIFF
--- a/src/main/java/com/zvyap/hoyoapi/APIEnvironment.java
+++ b/src/main/java/com/zvyap/hoyoapi/APIEnvironment.java
@@ -41,8 +41,15 @@ public enum APIEnvironment {
                     .dailyCheckInApiEndpoint("https://sg-public-api.hoyolab.com/event/luna/os")
                     .dailyCheckInActId("e202202281857121")
                     .gameBiz("nxx_global")
+                    .build(),
+            GameAPIConstant.builder()
+                    .gameType(GameType.ZENLESS_ZONE_ZERO)
+                    .name("Zenless Zone Zero")
+                    .apiUrl("https://sg-act-nap-api.hoyolab.com")
+                    .dailyCheckInApiEndpoint("https://sg-act-nap-api.hoyolab.com/event/luna/zzz/os")
+                    .dailyCheckInActId("e202406031448091")
+                    .gameBiz("nap_global")
                     .build()),
-    //Zenless Zone Zero id - 8
 
     CHINA(AccountAPIConstant.builder()
             .userGameRoleEndpoint("https://api-takumi.mihoyo.com/binding/api/getUserGameRolesByLtoken")
@@ -81,6 +88,15 @@ public enum APIEnvironment {
                     .dailyCheckInApiEndpoint("https://api-takumi.mihoyo.com/event/luna")
                     .dailyCheckInActId("e202202251749321")
                     .gameBiz("nxx_cn")
+                    .build(),
+            // TODO: implement urls
+            GameAPIConstant.builder()
+                    .gameType(GameType.ZENLESS_ZONE_ZERO)
+                    .name("绝区零")
+                    .apiUrl("")
+                    .dailyCheckInApiEndpoint("")
+                    .dailyCheckInActId("")
+                    .gameBiz("nap_cn")
                     .build());
 
     private final AccountAPIConstant accountAPIConstant;
@@ -88,13 +104,15 @@ public enum APIEnvironment {
     public final GameAPIConstant HONKAI_IMPACT_3RD;
     public final GameAPIConstant HONKAI_STAR_RAIL;
     public final GameAPIConstant TEARS_OF_THEMIS;
+    public final GameAPIConstant ZENLESS_ZONE_ZERO;
 
-    APIEnvironment(AccountAPIConstant accountAPIConstant, GameAPIConstant GENSHIN, GameAPIConstant HONKAI_IMPACT_3RD, GameAPIConstant HONKAI_STAR_RAIL, GameAPIConstant TEARS_OF_THEMIS) {
+    APIEnvironment(AccountAPIConstant accountAPIConstant, GameAPIConstant GENSHIN, GameAPIConstant HONKAI_IMPACT_3RD, GameAPIConstant HONKAI_STAR_RAIL, GameAPIConstant TEARS_OF_THEMIS, GameAPIConstant ZENLESS_ZONE_ZERO) {
         this.accountAPIConstant = accountAPIConstant;
         this.GENSHIN = GENSHIN;
         this.HONKAI_IMPACT_3RD = HONKAI_IMPACT_3RD;
         this.HONKAI_STAR_RAIL = HONKAI_STAR_RAIL;
         this.TEARS_OF_THEMIS = TEARS_OF_THEMIS;
+        this.ZENLESS_ZONE_ZERO = ZENLESS_ZONE_ZERO;
     }
 
     public AccountAPIConstant getAccountAPIConstant() {
@@ -102,7 +120,7 @@ public enum APIEnvironment {
     }
 
     public GameAPIConstant[] getAllAPIConstant() {
-        return new GameAPIConstant[] {GENSHIN, HONKAI_IMPACT_3RD, HONKAI_STAR_RAIL, TEARS_OF_THEMIS};
+        return new GameAPIConstant[] {GENSHIN, HONKAI_IMPACT_3RD, HONKAI_STAR_RAIL, TEARS_OF_THEMIS, ZENLESS_ZONE_ZERO};
     }
 
     public GameAPIConstant getAPIConstant(GameType gameType) {
@@ -115,6 +133,8 @@ public enum APIEnvironment {
                 return HONKAI_STAR_RAIL;
             case TEARS_OF_THEMIS:
                 return TEARS_OF_THEMIS;
+            case ZENLESS_ZONE_ZERO:
+                return ZENLESS_ZONE_ZERO;
             default:
                 throw new HoyoverseAPIMissingException("GameAPIConstant");
         }

--- a/src/main/java/com/zvyap/hoyoapi/GameType.java
+++ b/src/main/java/com/zvyap/hoyoapi/GameType.java
@@ -5,7 +5,8 @@ public enum GameType {
     HONKAI_IMPACT_3RD(1),
     HONKAI_STAR_RAIL(6),
     TEARS_OF_THEMIS(4),
-    ZENLESS_ZONE_ZERO(8); //unimplemented yet
+    /** Not implemented on {@link APIEnvironment#CHINA} yet. */
+    ZENLESS_ZONE_ZERO(8);
 
     private final int gameId;
 

--- a/src/test/java/com/zvyap/hoyoapi/test/APITest.java
+++ b/src/test/java/com/zvyap/hoyoapi/test/APITest.java
@@ -18,6 +18,7 @@ public class APITest {
         TestUtils.notNullAndPrint(api.getGameRoles(token, GameType.HONKAI_IMPACT_3RD));
         TestUtils.notNullAndPrint(api.getGameRoles(token, GameType.HONKAI_STAR_RAIL));
         TestUtils.notNullAndPrint(api.getGameRoles(token, GameType.TEARS_OF_THEMIS));
+        TestUtils.notNullAndPrint(api.getGameRoles(token, GameType.ZENLESS_ZONE_ZERO));
     }
 
     @Test

--- a/src/test/java/com/zvyap/hoyoapi/test/TestConstant.java
+++ b/src/test/java/com/zvyap/hoyoapi/test/TestConstant.java
@@ -8,6 +8,7 @@ public class TestConstant {
     public static final boolean HONKAI_TEST = true;
     public static final boolean HSR_TEST = true;
     public static final boolean TOT_TEST = true;
+    public static final boolean ZZZ_TEST = true;
 
     public static final String GLOBAL_TOKEN = System.getenv("GLOBAL_TOKEN");
     public static final String GLOBAL_TOKEN_ID = System.getenv("GLOBAL_TOKEN_ID");
@@ -19,6 +20,8 @@ public class TestConstant {
     public static final String HSR_TOKEN_ID = System.getenv("HSR_TOKEN_ID") == null ? GLOBAL_TOKEN_ID : System.getenv("HSR_TOKEN_ID");
     public static final String TOT_TOKEN = System.getenv("TOT_TOKEN") == null ? GLOBAL_TOKEN : System.getenv("TOT_TOKEN");
     public static final String TOT_TOKEN_ID = System.getenv("TOT_TOKEN_ID") == null ? GLOBAL_TOKEN_ID : System.getenv("TOT_TOKEN_ID");
+    public static final String ZZZ_TOKEN = System.getenv("ZZZ_TOKEN") == null ? GLOBAL_TOKEN : System.getenv("ZZZ_TOKEN");
+    public static final String ZZZ_TOKEN_ID = System.getenv("ZZZ_TOKEN_ID") == null ? GLOBAL_TOKEN_ID : System.getenv("ZZZ_TOKEN_ID");
 
     public static boolean isGenshinEnabled() {
         return GENSHIN_TEST && GENSHIN_TOKEN != null && GENSHIN_TOKEN_ID != null;
@@ -34,6 +37,10 @@ public class TestConstant {
 
     public static boolean isToTEnabled() {
         return TOT_TEST && TOT_TOKEN != null && TOT_TOKEN_ID != null;
+    }
+
+    public static boolean isZZZEnabled() {
+        return ZZZ_TEST && ZZZ_TOKEN != null && ZZZ_TOKEN_ID != null;
     }
 
     public static boolean isMainTestEnabled() {

--- a/src/test/java/com/zvyap/hoyoapi/test/feature/ZenlessZoneZeroDailyCheckInTest.java
+++ b/src/test/java/com/zvyap/hoyoapi/test/feature/ZenlessZoneZeroDailyCheckInTest.java
@@ -1,0 +1,47 @@
+package com.zvyap.hoyoapi.test.feature;
+
+import com.zvyap.hoyoapi.APIEnvironment;
+import com.zvyap.hoyoapi.GameType;
+import com.zvyap.hoyoapi.HoyoToken;
+import com.zvyap.hoyoapi.HoyoverseAPI;
+import com.zvyap.hoyoapi.feature.daily.DailyCheckInFeature;
+import com.zvyap.hoyoapi.test.TestConstant;
+import com.zvyap.hoyoapi.test.TestUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIf("com.zvyap.hoyoapi.test.TestConstant#isZZZEnabled")
+public class ZenlessZoneZeroDailyCheckInTest {
+
+    private HoyoverseAPI osAPI = new HoyoverseAPI(APIEnvironment.OVERSEA);
+    private HoyoToken token = HoyoToken.of(TestConstant.ZZZ_TOKEN_ID, TestConstant.ZZZ_TOKEN);
+
+    @Test
+    public void osZenlessZoneZeroDailyCheckInGetRewardTest() {
+        var response = new DailyCheckInFeature(osAPI).getAllReward(GameType.ZENLESS_ZONE_ZERO);
+        Assertions.assertNotNull(response);
+
+        TestUtils.notNullAndPrint(response);
+    }
+
+    @Test
+    public void osZenlessZoneZeroDailyCheckInGetDailyInfoTest() {
+        var response = new DailyCheckInFeature(osAPI).getDailyInfo(GameType.ZENLESS_ZONE_ZERO, token);
+        Assertions.assertNotNull(response);
+
+        TestUtils.notNullAndPrint(response);
+    }
+
+    @Test
+    @Disabled
+    public void osZenlessZoneZeroDailyCheckInSignDailyTest() {
+        var response = new DailyCheckInFeature(osAPI).signDaily(GameType.ZENLESS_ZONE_ZERO, token);
+        Assertions.assertNotNull(response);
+
+        TestUtils.notNullAndPrint(response);
+    }
+}


### PR DESCRIPTION
Adds support for Zenless Zone Zero on `APIEnvironment#OVERSEA`.

I am personally not Chinese and as a result I am not sure where to find the URLs necessary to implement it for `APIEnvironment#CHINA`.

Added relevant tests and manually verified on a local fork of `hoyoverse-github-action-daily-checkin` to work for check-ins.

![image](https://github.com/user-attachments/assets/0b0f67f3-0da1-4618-b2c6-333712b9343a)
 